### PR TITLE
Added resource extractor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,5 +10,6 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.10'
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.hamcrest:hamcrest-all:1.3'
 }

--- a/src/main/java/org/cirdles/commons/util/ResourceExtractor.java
+++ b/src/main/java/org/cirdles/commons/util/ResourceExtractor.java
@@ -1,0 +1,100 @@
+package org.cirdles.commons.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
+/**
+ * A utility for extracting resources into local files. This should be used to
+ * avoid issues when manipulating resources inside of a JAR or a WAR.
+ */
+public class ResourceExtractor {
+
+    private final ClassLoader classLoader;
+    private final Class<?> clazz;
+
+    /**
+     * Creates a new resource extractor.
+     *
+     * @param clazz the class whose class loader should be used to access
+     *              resources
+     */
+    public ResourceExtractor(Class<?> clazz) {
+        this.classLoader = null;
+        this.clazz = clazz;
+    }
+
+    /**
+     * Creates a new resource extractor.
+     *
+     * @param classLoader the class loader that should be used to access
+     *                    resources
+     */
+    public ResourceExtractor(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+        this.clazz = null;
+    }
+
+    /**
+     * Extracts a resource as a file.
+     *
+     * @param name the name of the resource
+     * @return a temporary file with the same contents as the resource
+     * @see Class#getResourceAsStream(String)
+     * @see ClassLoader#getResourceAsStream(String)
+     */
+    public File extractResourceAsFile(String name) {
+        File result = null;
+        Path resourcePath = extractResourceAsPath(name);
+
+        if (resourcePath != null) {
+            result = resourcePath.toFile();
+        }
+
+        return result;
+    }
+
+    private InputStream getResourceAsStream(String name) {
+        InputStream result = null;
+
+        if (classLoader != null) {
+            result = classLoader.getResourceAsStream(name);
+        } else if (clazz != null) {
+            result = clazz.getResourceAsStream(name);
+        }
+
+        return result;
+    }
+
+    /**
+     * Extracts a resource as a file path.
+     *
+     * @param name the name of the resource
+     * @return a temporary file path with the same contents as the resource
+     * @see Class#getResourceAsStream(String)
+     * @see ClassLoader#getResourceAsStream(String)
+     */
+    public Path extractResourceAsPath(String name) {
+        Path result = null;
+        InputStream resourceStream = getResourceAsStream(name);
+
+        // resource must be found
+        if (resourceStream != null) {
+            // should always succeed
+            try {
+                Path tempFile = Files.createTempFile(null, null);
+                Files.copy(resourceStream, tempFile, REPLACE_EXISTING);
+                result = tempFile;
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+
+        return result;
+    }
+
+}

--- a/src/test/java/org/cirdles/commons/util/ResourceExtractorTest.java
+++ b/src/test/java/org/cirdles/commons/util/ResourceExtractorTest.java
@@ -1,0 +1,43 @@
+package org.cirdles.commons.util;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Scanner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Created by johnzeringue on 9/15/15.
+ */
+public class ResourceExtractorTest {
+
+    private ResourceExtractor resourceExtractor;
+
+    @Before
+    public void setUp() {
+        resourceExtractor = new ResourceExtractor(this.getClass());
+    }
+
+    @Test
+    public void testExtractResourceAsFile() throws Throwable {
+        File file = resourceExtractor
+                .extractResourceAsFile("resourceExtractorTest.txt");
+
+        Scanner scanner = new Scanner(file, "UTF-8");
+        assertThat(scanner.nextLine(), is("Hello, World!"));
+    }
+
+    @Test
+    public void testExtractResourceAsPath() throws Throwable {
+        Path path = resourceExtractor
+                .extractResourceAsPath("resourceExtractorTest.txt");
+
+        Scanner scanner = new Scanner(path, "UTF-8");
+        assertThat(scanner.nextLine(), is("Hello, World!"));
+    }
+
+}

--- a/src/test/resources/org/cirdles/commons/util/resourceExtractorTest.txt
+++ b/src/test/resources/org/cirdles/commons/util/resourceExtractorTest.txt
@@ -1,0 +1,1 @@
+Hello, World!


### PR DESCRIPTION
Added a resource extractor (`ResourceExtractor`) to Commons. This is a
utility to create temp files from resources.

It is best practice to use this class over `Class#getResource(String)`
in all cases. `Class#getResource(String)` is not safe to use for
resources in JARs and WARs.
